### PR TITLE
Static binding factory

### DIFF
--- a/NativeTK.sln
+++ b/NativeTK.sln
@@ -5,7 +5,9 @@ VisualStudioVersion = 15.0.26124.0
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProjectCeilidh.NativeTK", "ProjectCeilidh.NativeTK\ProjectCeilidh.NativeTK.csproj", "{895EA29E-4A28-4442-80C0-8E4C7A68E21A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectCeilidh.NativeTK.Tests", "ProjectCeilidh.NativeTK.Tests\ProjectCeilidh.NativeTK.Tests.csproj", "{6613BE4A-CFAE-4E88-A1C4-D72C48E620D1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProjectCeilidh.NativeTK.Tests", "ProjectCeilidh.NativeTK.Tests\ProjectCeilidh.NativeTK.Tests.csproj", "{6613BE4A-CFAE-4E88-A1C4-D72C48E620D1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectCeilidh.NativeTK.Benchmark", "ProjectCeilidh.NativeTK.Benchmark\ProjectCeilidh.NativeTK.Benchmark.csproj", "{C0F89064-2E15-4EB7-9311-8F3ED02DF5E8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -41,6 +43,18 @@ Global
 		{6613BE4A-CFAE-4E88-A1C4-D72C48E620D1}.Release|x64.Build.0 = Release|Any CPU
 		{6613BE4A-CFAE-4E88-A1C4-D72C48E620D1}.Release|x86.ActiveCfg = Release|Any CPU
 		{6613BE4A-CFAE-4E88-A1C4-D72C48E620D1}.Release|x86.Build.0 = Release|Any CPU
+		{C0F89064-2E15-4EB7-9311-8F3ED02DF5E8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C0F89064-2E15-4EB7-9311-8F3ED02DF5E8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C0F89064-2E15-4EB7-9311-8F3ED02DF5E8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C0F89064-2E15-4EB7-9311-8F3ED02DF5E8}.Debug|x64.Build.0 = Debug|Any CPU
+		{C0F89064-2E15-4EB7-9311-8F3ED02DF5E8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C0F89064-2E15-4EB7-9311-8F3ED02DF5E8}.Debug|x86.Build.0 = Debug|Any CPU
+		{C0F89064-2E15-4EB7-9311-8F3ED02DF5E8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C0F89064-2E15-4EB7-9311-8F3ED02DF5E8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C0F89064-2E15-4EB7-9311-8F3ED02DF5E8}.Release|x64.ActiveCfg = Release|Any CPU
+		{C0F89064-2E15-4EB7-9311-8F3ED02DF5E8}.Release|x64.Build.0 = Release|Any CPU
+		{C0F89064-2E15-4EB7-9311-8F3ED02DF5E8}.Release|x86.ActiveCfg = Release|Any CPU
+		{C0F89064-2E15-4EB7-9311-8F3ED02DF5E8}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ProjectCeilidh.NativeTK.Benchmark/Program.cs
+++ b/ProjectCeilidh.NativeTK.Benchmark/Program.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+using ProjectCeilidh.NativeTK.Attributes;
+
+namespace ProjectCeilidh.NativeTK.Benchmark
+{
+    public class Program
+    {
+        [CoreJob]
+        [RankColumn, MedianColumn]
+        public class Benchmark
+        {
+            private static readonly ITestBinding IndirectBinding = BindingFactory.CreateBinding<ITestBinding>(NativeBindingType.Indirect);
+            private static readonly ITestBinding StaticBinding = BindingFactory.CreateBinding<ITestBinding>();
+
+            [Benchmark]
+            public void Indirect()
+            {
+                var ptr = IndirectBinding.GlobalAlloc(0, (IntPtr) 1024);
+                IndirectBinding.GlobalFree(ptr);
+            }
+
+            [Benchmark]
+            public void Static()
+            {
+                var ptr = StaticBinding.GlobalAlloc(0, (IntPtr)1024);
+                StaticBinding.GlobalFree(ptr);
+            }
+
+            [Benchmark(Baseline = true)]
+            public void Baseline()
+            {
+                var ptr = GlobalAlloc(0, (IntPtr)1024);
+                GlobalFree(ptr);
+            }
+
+            [DllImport("kernel32", CallingConvention = CallingConvention.Winapi)]
+            private static extern IntPtr GlobalAlloc(uint uFlags, IntPtr dwBytes);
+            
+            [DllImport("Kernel32", CallingConvention = CallingConvention.Winapi)]
+            private static extern IntPtr GlobalFree(IntPtr hMem);
+        }
+
+        private static void Main()
+        {
+            BenchmarkRunner.Run<Benchmark>();
+        }
+
+        [NativeLibraryContract("kernel32")]
+        public interface ITestBinding
+        {
+            [NativeImport(CallingConvention = CallingConvention.Winapi)]
+            IntPtr GlobalAlloc(uint uFlags, IntPtr dwBytes);
+
+            [NativeImport(CallingConvention = CallingConvention.Winapi)]
+            IntPtr GlobalFree(IntPtr hMem);
+        }
+    }
+}

--- a/ProjectCeilidh.NativeTK.Benchmark/ProjectCeilidh.NativeTK.Benchmark.csproj
+++ b/ProjectCeilidh.NativeTK.Benchmark/ProjectCeilidh.NativeTK.Benchmark.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ProjectCeilidh.NativeTK\ProjectCeilidh.NativeTK.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ProjectCeilidh.NativeTK.Tests/BindingTests.cs
+++ b/ProjectCeilidh.NativeTK.Tests/BindingTests.cs
@@ -33,7 +33,8 @@ namespace ProjectCeilidh.NativeTK.Tests
             ref IntPtr dlsym { get; }
 
             [NativeImport]
-            IntPtr dlopen(string path, int flag);
+            [return: MarshalAs(UnmanagedType.SysInt)]
+            IntPtr dlopen([MarshalAs(UnmanagedType.LPStr)] string path, [MarshalAs(UnmanagedType.I4)] int flag);
         }
 
         [NativeLibraryContract("kernel32")]
@@ -43,7 +44,8 @@ namespace ProjectCeilidh.NativeTK.Tests
             ref IntPtr GetCommandLineWRef { get; }
 
             [NativeImport(SetLastError = true, CallingConvention = CallingConvention.Winapi)]
-            IntPtr GetStdHandle(int nStdHandle);
+            [return: MarshalAs(UnmanagedType.SysInt)]
+            IntPtr GetStdHandle([MarshalAs(UnmanagedType.I4)] int nStdHandle);
         }
     }
 }

--- a/ProjectCeilidh.NativeTK.Tests/BindingTests.cs
+++ b/ProjectCeilidh.NativeTK.Tests/BindingTests.cs
@@ -7,38 +7,20 @@ namespace ProjectCeilidh.NativeTK.Tests
 {
     public class BindingTests
     {
-        [return: MarshalAs(UnmanagedType.SysInt)]
-        private delegate IntPtr TestDelegate([MarshalAs(UnmanagedType.I4)] int i);
-
-        [Fact]
-        public void UnsafeBindingTest()
+        [Theory]
+        [InlineData(NativeBindingType.Indirect)]
+        [InlineData(NativeBindingType.Static)]
+        public void BindingTest(NativeBindingType bindingType)
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                var binding = BindingFactory.CreateBinding<ITestBindingWindows>();
+                var binding = BindingFactory.CreateBinding<ITestBindingWindows>(bindingType);
                 Assert.NotEqual(IntPtr.Zero, binding.GetStdHandle(-11));
                 ref var _ = ref binding.GetCommandLineWRef;
             }
             else
             {
-                var binding = BindingFactory.CreateBinding<ITestBindingUnix>();
-                Assert.Equal(IntPtr.Zero, binding.dlopen("", 0));
-                ref var _ = ref binding.dlsym;
-            }
-        }
-
-        [Fact]
-        public void SafeBindingTest()
-        {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                var binding = BindingFactory.CreateSafeBinding<ITestBindingWindows>();
-                Assert.NotEqual(IntPtr.Zero, binding.GetStdHandle(-11));
-                ref var _ = ref binding.GetCommandLineWRef;
-            }
-            else
-            {
-                var binding = BindingFactory.CreateSafeBinding<ITestBindingUnix>();
+                var binding = BindingFactory.CreateBinding<ITestBindingUnix>(bindingType);
                 Assert.Equal(IntPtr.Zero, binding.dlopen("", 0));
                 ref var _ = ref binding.dlsym;
             }
@@ -60,7 +42,7 @@ namespace ProjectCeilidh.NativeTK.Tests
             [NativeImport(EntryPoint = "GetCommandLineW")]
             ref IntPtr GetCommandLineWRef { get; }
 
-            [NativeImport(SetLastError = true)]
+            [NativeImport(SetLastError = true, CallingConvention = CallingConvention.Winapi)]
             IntPtr GetStdHandle(int nStdHandle);
         }
     }

--- a/ProjectCeilidh.NativeTK/BindingFactory.cs
+++ b/ProjectCeilidh.NativeTK/BindingFactory.cs
@@ -1,14 +1,11 @@
 ﻿using System;
 using System.IO;
-using System.Linq;
 using System.Runtime.InteropServices;
 using Mono.Cecil;
 using ProjectCeilidh.NativeTK.Attributes;
 using ProjectCeilidh.NativeTK.Native;
 using System.Reflection;
 using Mono.Cecil.Cil;
-using CustomAttributeNamedArgument = Mono.Cecil.CustomAttributeNamedArgument;
-using FieldAttributes = Mono.Cecil.FieldAttributes;
 using MethodAttributes = Mono.Cecil.MethodAttributes;
 using MethodImplAttributes = Mono.Cecil.MethodImplAttributes;
 using ParameterAttributes = Mono.Cecil.ParameterAttributes;
@@ -17,17 +14,44 @@ using TypeAttributes = Mono.Cecil.TypeAttributes;
 
 namespace ProjectCeilidh.NativeTK
 {
-    public static class BindingFactory
+    public enum NativeBindingType
     {
         /// <summary>
+        /// Bind native functions using the CallIndirect opcode.
+        /// This has poor compatibility and does not support marshaling options
+        /// </summary>
+        Indirect = 1,
+        /// <summary>
+        /// Bind native functions using PInvokeImpl.
+        /// This has the best compatibility, supporting marshaling options, but is slightly slower.
+        /// </summary>
+        Static = 2
+    }
+
+    public static class BindingFactory
+    {
+        public static T CreateBinding<T>(NativeBindingType bindingType = NativeBindingType.Static) where T : class
+        {
+            switch (bindingType)
+            {
+                case NativeBindingType.Indirect:
+                    return CreateIndirectBinding<T>();
+                case NativeBindingType.Static:
+                    return CreateStaticBinding<T>();
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(bindingType), bindingType, null);
+            }
+        }
+
+        /// <summary>
         /// Create an implementation for a given interface, binding native methods.
-        /// On compatible platforms, this is achieved using "CallIndirect"
+        /// On compatible platforms, this is achieved using "CallIndirect".
         /// </summary>
         /// <typeparam name="T">The interface type to implement</typeparam>
         /// <returns>An instance binding the specified native interface.</returns>
-        public static T CreateBinding<T>() where T : class 
+        private static T CreateIndirectBinding<T>() where T : class 
         {
-            if (RuntimeInformation.ProcessArchitecture == Architecture.X86) return CreateSafeBinding<T>();
+            if (RuntimeInformation.ProcessArchitecture == Architecture.X86) throw new PlatformNotSupportedException();
 
             // Get the NativeLibraryLoader for this platform
             var loader = NativeLibraryLoader.GetLibraryLoaderForPlatform();
@@ -171,12 +195,15 @@ namespace ProjectCeilidh.NativeTK
 
         /// <summary>
         /// Create an implementation for a given interface, binding native methods.
-        /// This is achieved using delegates, translating parameter and return value annotations to allow custom marshaling.
+        /// This is achieved by generating a class with DLLImport attributes.
         /// </summary>
-        /// <typeparam name="T">The interface type to implement</typeparam>
-        /// <returns>An instance binding the specified native interface.</returns>
-        public static T CreateSafeBinding<T>()
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        private static T CreateStaticBinding<T>() where T : class 
         {
+            // Get the NativeLibraryLoader for this platform
+            var loader = NativeLibraryLoader.GetLibraryLoaderForPlatform();
+
             var intTyp = typeof(T);
 
             if (!intTyp.IsInterface) throw new ArgumentException("Type argument must be an interface.");
@@ -185,7 +212,6 @@ namespace ProjectCeilidh.NativeTK
 
             if (libraryAttr == null) throw new ArgumentException("Type argument must have a NativeLibraryContractAttribute");
 
-            var loader = NativeLibraryLoader.GetLibraryLoaderForPlatform();
             var handle = loader.LoadNativeLibrary(libraryAttr.LibraryName, libraryAttr.Version);
 
             // Create the dynamic assembly which will contain the binding
@@ -196,25 +222,16 @@ namespace ProjectCeilidh.NativeTK
             implTyp.Interfaces.Add(new InterfaceImplementation(asm.MainModule.ImportReference(intTyp)));
             asm.MainModule.Types.Add(implTyp);
 
-            var handleField = new FieldDefinition("_handle", FieldAttributes.Private | FieldAttributes.InitOnly, asm.MainModule.ImportReference(typeof(NativeLibraryHandle)));
-            implTyp.Fields.Add(handleField);
-
             // Create a default constructor for the binding type
             var implCtor = new MethodDefinition(".ctor",
                 MethodAttributes.SpecialName | MethodAttributes.RTSpecialName | MethodAttributes.Public |
-                MethodAttributes.HideBySig, asm.MainModule.TypeSystem.Void)
-            {
-                Parameters = { new ParameterDefinition("handle", ParameterAttributes.None, asm.MainModule.ImportReference(typeof(NativeLibraryHandle))) }
-            };
+                MethodAttributes.HideBySig, asm.MainModule.TypeSystem.Void);
             implTyp.Methods.Add(implCtor);
             // Simple ctor body - load `this`, call `new object()` against it
             var ctorProc = implCtor.Body.GetILProcessor();
             ctorProc.Emit(OpCodes.Ldarg_0);
             ctorProc.Emit(OpCodes.Call, asm.MainModule.ImportReference(typeof(object).GetConstructor(new Type[0])));
-
-            ctorProc.Emit(OpCodes.Ldarg_0);
-            ctorProc.Emit(OpCodes.Ldarg_1);
-            ctorProc.Emit(OpCodes.Stfld, handleField);
+            ctorProc.Emit(OpCodes.Ret);
 
             // Implement all the methods in the interface
             foreach (var intMethod in intTyp.GetMethods())
@@ -229,106 +246,77 @@ namespace ProjectCeilidh.NativeTK
 
                 if (intAttr == null) throw new ArgumentException($"Type argument contains a method without a NativeImportAttribute ({intMethod.Name})");
 
-                // Create a delegate type which
-                var delegateType = new TypeDefinition("", Guid.NewGuid().ToString("N"),
-                    TypeAttributes.Class
-                    | TypeAttributes.NestedPrivate
-                    | TypeAttributes.Sealed
-                    | TypeAttributes.AnsiClass
-                    | TypeAttributes.AutoClass,
-                    asm.MainModule.ImportReference(typeof(MulticastDelegate)));
-                implTyp.NestedTypes.Add(delegateType);
-
-                var ptrAttr = new CustomAttribute(asm.MainModule.ImportReference(
-                    typeof(UnmanagedFunctionPointerAttribute).GetConstructor(new[] {typeof(CallingConvention)})))
+                // Create a static method with a PInvokeImpl that points to the library / function we want
+                var bindMeth = new MethodDefinition($"{intMethod.Name}Impl",
+                    MethodAttributes.Private | MethodAttributes.Static | MethodAttributes.PInvokeImpl | MethodAttributes.HideBySig,
+                    asm.MainModule.ImportReference(intMethod.ReturnType))
                 {
-                    ConstructorArguments =
+                    ImplAttributes = MethodImplAttributes.PreserveSig,
+                };
+
+                {
+                    var module = new ModuleReference(handle.LibraryPath);
+                    asm.MainModule.ModuleReferences.Add(module);
+
+                    var pInvokeAttributes = PInvokeAttributes.NoMangle;
+                    switch (intAttr.CallingConvention)
                     {
-                        new CustomAttributeArgument(asm.MainModule.ImportReference(typeof(CallingConvention)),
-                            (int)intAttr.CallingConvention)
-                    },
-                    Properties =
-                    {
-                        new CustomAttributeNamedArgument(
-                            nameof(UnmanagedFunctionPointerAttribute.CharSet),
-                            new CustomAttributeArgument(asm.MainModule.ImportReference(typeof(CharSet)),
-                                (int)intAttr.CharSet)),
-                        new CustomAttributeNamedArgument(
-                            nameof(UnmanagedFunctionPointerAttribute.BestFitMapping),
-                            new CustomAttributeArgument(asm.MainModule.TypeSystem.Boolean, intAttr.BestFitMapping)),
-                        new CustomAttributeNamedArgument(
-                            nameof(UnmanagedFunctionPointerAttribute.SetLastError),
-                            new CustomAttributeArgument(asm.MainModule.TypeSystem.Boolean, intAttr.SetLastError)),
-                        new CustomAttributeNamedArgument(
-                            nameof(UnmanagedFunctionPointerAttribute.ThrowOnUnmappableChar),
-                            new CustomAttributeArgument(asm.MainModule.TypeSystem.Boolean,
-                                intAttr.ThrowOnUnmappableChar))
+                        case CallingConvention.Cdecl:
+                            pInvokeAttributes |= PInvokeAttributes.CallConvCdecl;
+                            break;
+                        case CallingConvention.FastCall:
+                            pInvokeAttributes |= PInvokeAttributes.CallConvFastcall;
+                            break;
+                        case CallingConvention.StdCall:
+                            pInvokeAttributes |= PInvokeAttributes.CallConvStdCall;
+                            break;
+                        case CallingConvention.ThisCall:
+                            pInvokeAttributes |= PInvokeAttributes.CallConvThiscall;
+                            break;
+                        case CallingConvention.Winapi:
+                            pInvokeAttributes |= PInvokeAttributes.CallConvWinapi;
+                            break;
+                        default:
+                            throw new ArgumentOutOfRangeException();
                     }
-                };
-                delegateType.CustomAttributes.Add(ptrAttr);
 
-                var delegateCtor = new MethodDefinition(".ctor",
-                    MethodAttributes.RTSpecialName | MethodAttributes.HideBySig | MethodAttributes.Public,
-                    asm.MainModule.TypeSystem.Void)
+                    switch (intAttr.CharSet)
+                    {
+                        case CharSet.Ansi:
+                            pInvokeAttributes |= PInvokeAttributes.CharSetAnsi;
+                            break;
+                        case CharSet.Auto:
+                            pInvokeAttributes |= PInvokeAttributes.CharSetAuto;
+                            break;
+                        case CharSet.None:
+                            pInvokeAttributes |= PInvokeAttributes.CharSetNotSpec;
+                            break;
+                        case CharSet.Unicode:
+                            pInvokeAttributes |= PInvokeAttributes.CharSetUnicode;
+                            break;
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+
+                    if (intAttr.SetLastError) pInvokeAttributes |= PInvokeAttributes.SupportsLastError;
+                    pInvokeAttributes |= intAttr.BestFitMapping
+                        ? PInvokeAttributes.BestFitEnabled
+                        : PInvokeAttributes.BestFitDisabled;
+                    pInvokeAttributes |= intAttr.ThrowOnUnmappableChar
+                        ? PInvokeAttributes.ThrowOnUnmappableCharEnabled
+                        : PInvokeAttributes.ThrowOnUnmappableCharDisabled;
+
+                    bindMeth.PInvokeInfo = new PInvokeInfo(pInvokeAttributes, intAttr.EntryPoint ?? intMethod.Name, module);
+                }
+                
+                // Add all the parameters we want
+                foreach (var parameter in intMethod.GetParameters())
                 {
-                    ImplAttributes = MethodImplAttributes.Runtime | MethodImplAttributes.Managed,
-                    Parameters = { new ParameterDefinition(asm.MainModule.TypeSystem.Object), new ParameterDefinition(asm.MainModule.TypeSystem.IntPtr) }
-                };
-                delegateType.Methods.Add(delegateCtor);
-
-                var delegateInvoke = new MethodDefinition("Invoke",
-                    MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.NewSlot |
-                    MethodAttributes.Virtual, asm.MainModule.ImportReference(intMethod.ReturnType))
-                {
-                    ImplAttributes = MethodImplAttributes.Runtime | MethodImplAttributes.Managed
-                };
-                delegateType.Methods.Add(delegateInvoke);
-
-                foreach (var attr in intMethod.ReturnParameter?.CustomAttributes ?? Enumerable.Empty<CustomAttributeData>())
-                {
-                    var customAttr = new CustomAttribute(asm.MainModule.ImportReference(attr.Constructor));
-
-                    foreach (var ctorArgument in attr.ConstructorArguments)
-                        customAttr.ConstructorArguments.Add(new CustomAttributeArgument(asm.MainModule.ImportReference(ctorArgument.ArgumentType), ctorArgument.Value));
-                    foreach (var namedArgument in attr.NamedArguments ?? Enumerable.Empty<System.Reflection.CustomAttributeNamedArgument>())
-                        customAttr.Properties.Add(new CustomAttributeNamedArgument(namedArgument.MemberName, new CustomAttributeArgument(asm.MainModule.ImportReference(namedArgument.TypedValue.ArgumentType), namedArgument.TypedValue.Value)));
-
-                    delegateInvoke.MethodReturnType.CustomAttributes.Add(customAttr);
+                    var implParam = new ParameterDefinition(parameter.Name, (ParameterAttributes) parameter.Attributes, asm.MainModule.ImportReference(parameter.ParameterType));
+                    bindMeth.Parameters.Add(implParam);
                 }
 
-                foreach (var parameterInfo in intMethod.GetParameters())
-                {
-                    var parDef = new ParameterDefinition(parameterInfo.Name,
-                        (ParameterAttributes) parameterInfo.Attributes,
-                        asm.MainModule.ImportReference(parameterInfo.ParameterType));
-                    delegateInvoke.Parameters.Add(parDef);
-
-                    foreach (var attr in parameterInfo.CustomAttributes)
-                    {
-                        var customAttr = new CustomAttribute(asm.MainModule.ImportReference(attr.Constructor));
-
-                        foreach (var ctorArgument in attr.ConstructorArguments)
-                            customAttr.ConstructorArguments.Add(new CustomAttributeArgument(asm.MainModule.ImportReference(ctorArgument.ArgumentType), ctorArgument.Value));
-                        foreach (var namedArgument in attr.NamedArguments)
-                            customAttr.Properties.Add(new CustomAttributeNamedArgument(namedArgument.MemberName, new CustomAttributeArgument(asm.MainModule.ImportReference(namedArgument.TypedValue.ArgumentType), namedArgument.TypedValue.Value)));
-
-                        parDef.CustomAttributes.Add(customAttr);
-                    }
-                }
-
-                var field = new FieldDefinition(Guid.NewGuid().ToString("N"), FieldAttributes.InitOnly | FieldAttributes.Private, delegateType);
-                implTyp.Fields.Add(field);
-
-                var getDelegateRef = new GenericInstanceMethod(asm.MainModule.ImportReference(
-                    typeof(NativeLibraryHandle).GetMethod(nameof(NativeLibraryHandle.GetDelegateForSymbol))));
-                getDelegateRef.GenericArguments.Add(delegateType);
-
-                ctorProc.Emit(OpCodes.Ldarg_0);
-                ctorProc.Emit(OpCodes.Ldarg_1);
-                ctorProc.Emit(OpCodes.Ldstr, intAttr.EntryPoint ?? intMethod.Name);
-                ctorProc.Emit(OpCodes.Ldc_I4_1);
-                ctorProc.Emit(OpCodes.Call, getDelegateRef);
-                ctorProc.Emit(OpCodes.Stfld, field);
+                implTyp.Methods.Add(bindMeth);
 
                 // Create the dynamic method for the implementation
                 var meth = new MethodDefinition(intMethod.Name,
@@ -340,9 +328,6 @@ namespace ProjectCeilidh.NativeTK
                 // The body for the dynamic method
                 var proc = meth.Body.GetILProcessor();
 
-                proc.Emit(OpCodes.Ldarg_0);
-                proc.Emit(OpCodes.Ldfld, field);
-
                 var i = 0;
                 foreach (var param in intMethod.GetParameters())
                 {
@@ -352,8 +337,8 @@ namespace ProjectCeilidh.NativeTK
                     proc.Emit(OpCodes.Ldarg, ++i);
                 }
 
-                // Invoke the delegate
-                proc.Emit(OpCodes.Call, delegateInvoke);
+                // Invoke the method with a Call, then return the result
+                proc.Emit(OpCodes.Call, bindMeth);
                 proc.Emit(OpCodes.Ret);
             }
 
@@ -389,15 +374,13 @@ namespace ProjectCeilidh.NativeTK
                 getProc.Emit(OpCodes.Ret);
             }
 
-            ctorProc.Emit(OpCodes.Ret);
-
             // Write the newly generated assembly to memory, load it, and instatiate the newly generated binding
             using (var mem = new MemoryStream())
             {
                 asm.Write(mem);
                 var newAsm = Assembly.Load(mem.ToArray());
                 var newTyp = newAsm.GetType($"{intTyp.Name}Impl");
-                return (T)newTyp.GetConstructor(new[] { typeof(NativeLibraryHandle) })?.Invoke(new object[] { handle });
+                return (T)newTyp.GetConstructor(new Type[0])?.Invoke(new object[0]);
             }
         }
     }

--- a/ProjectCeilidh.NativeTK/Native/NativeLibraryHandle.cs
+++ b/ProjectCeilidh.NativeTK/Native/NativeLibraryHandle.cs
@@ -6,7 +6,12 @@ namespace ProjectCeilidh.NativeTK.Native
 {
     public abstract class NativeLibraryHandle
     {
-        internal NativeLibraryHandle() { }
+        public string LibraryPath { get; }
+
+        internal NativeLibraryHandle(string libraryPath)
+        {
+            LibraryPath = libraryPath;
+        }
 
         /// <summary>
         /// Get a delegate for the function represented by a given symbol.

--- a/ProjectCeilidh.NativeTK/Native/Platform/LinuxNativeLibraryLoader.cs
+++ b/ProjectCeilidh.NativeTK/Native/Platform/LinuxNativeLibraryLoader.cs
@@ -22,7 +22,7 @@ namespace ProjectCeilidh.NativeTK.Native.Platform
         protected override NativeLibraryHandle LoadNativeLibrary(string libraryName)
         {
             var handle = dlopen(libraryName, RTLD_NOW);
-            return handle == IntPtr.Zero ? null : new LinuxNativeLibraryHandle(handle);
+            return handle == IntPtr.Zero ? null : new LinuxNativeLibraryHandle(libraryName, handle);
         }
         
         [DllImport(LIBDL)]
@@ -34,7 +34,7 @@ namespace ProjectCeilidh.NativeTK.Native.Platform
         {
             private readonly IntPtr _handle;
             
-            public LinuxNativeLibraryHandle(IntPtr handle)
+            public LinuxNativeLibraryHandle(string path, IntPtr handle) : base(path)
             {
                 _handle = handle;
             }

--- a/ProjectCeilidh.NativeTK/Native/Platform/MacNativeLibraryLoader.cs
+++ b/ProjectCeilidh.NativeTK/Native/Platform/MacNativeLibraryLoader.cs
@@ -22,7 +22,7 @@ namespace ProjectCeilidh.NativeTK.Native.Platform
         protected override NativeLibraryHandle LoadNativeLibrary(string libraryName)
         {
             var handle = dlopen(libraryName, RTLD_NOW);
-            return handle == IntPtr.Zero ? null : new MacNativeLibraryHandle(handle);
+            return handle == IntPtr.Zero ? null : new MacNativeLibraryHandle(libraryName, handle);
         }
         
         [DllImport(LIBDL)]
@@ -34,7 +34,7 @@ namespace ProjectCeilidh.NativeTK.Native.Platform
         {
             private readonly IntPtr _handle;
             
-            public MacNativeLibraryHandle(IntPtr handle)
+            public MacNativeLibraryHandle(string path, IntPtr handle) : base(path)
             {
                 _handle = handle;
             }

--- a/ProjectCeilidh.NativeTK/Native/Platform/WindowsNativeLibraryLoader.cs
+++ b/ProjectCeilidh.NativeTK/Native/Platform/WindowsNativeLibraryLoader.cs
@@ -27,7 +27,7 @@ namespace ProjectCeilidh.NativeTK.Native.Platform
         protected override NativeLibraryHandle LoadNativeLibrary(string libraryName)
         {
             var handle = LoadLibrary(libraryName);
-            return handle == IntPtr.Zero ? null : new WindowsNativeLibraryHandle(handle);
+            return handle == IntPtr.Zero ? null : new WindowsNativeLibraryHandle(libraryName, handle);
         }
 
         [DllImport(KERNEL32, SetLastError = true)]
@@ -40,7 +40,7 @@ namespace ProjectCeilidh.NativeTK.Native.Platform
         {
             private readonly IntPtr _handle;
             
-            public WindowsNativeLibraryHandle(IntPtr handle)
+            public WindowsNativeLibraryHandle(string path, IntPtr handle) : base(path)
             {
                 _handle = handle;
             }

--- a/ProjectCeilidh.NativeTK/ProjectCeilidh.NativeTK.csproj
+++ b/ProjectCeilidh.NativeTK/ProjectCeilidh.NativeTK.csproj
@@ -5,6 +5,9 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AutoGenerateBindingRedirects></AutoGenerateBindingRedirects>
+    <Authors>Olivia Trewin</Authors>
+    <Company>Project Ceilidh</Company>
+    <Description>A toolkit for cross-platform P/Invoke in C#</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ProjectCeilidh.NativeTK/ProjectCeilidh.NativeTK.csproj
+++ b/ProjectCeilidh.NativeTK/ProjectCeilidh.NativeTK.csproj
@@ -12,6 +12,7 @@
     <RepositoryUrl>https://github.com/Ceilidh-Team/NativeTK</RepositoryUrl>
     <PackageLicenseUrl>https://github.com/Ceilidh-Team/NativeTK/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Ceilidh-Team/NativeTK</PackageProjectUrl>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ProjectCeilidh.NativeTK/ProjectCeilidh.NativeTK.csproj
+++ b/ProjectCeilidh.NativeTK/ProjectCeilidh.NativeTK.csproj
@@ -8,6 +8,10 @@
     <Authors>Olivia Trewin</Authors>
     <Company>Project Ceilidh</Company>
     <Description>A toolkit for cross-platform P/Invoke in C#</Description>
+    <Copyright>Olivia Trewin (c) 2018</Copyright>
+    <RepositoryUrl>https://github.com/Ceilidh-Team/NativeTK</RepositoryUrl>
+    <PackageLicenseUrl>https://github.com/Ceilidh-Team/NativeTK/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/Ceilidh-Team/NativeTK</PackageProjectUrl>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Added the ability to create "static" bindings, which use `PInvokeImpl` and support `MarshalAsAttribute`, plus other more specific binding information
* Added a benchmark
* Removed the delegate-based "safe" binding